### PR TITLE
add context manager to cluster

### DIFF
--- a/pyjaws/pyjaws/api/base.py
+++ b/pyjaws/pyjaws/api/base.py
@@ -54,6 +54,12 @@ class Cluster(BaseModel):
     def __str__(self):
         return self.job_cluster_key
 
+    def __enter__(self) -> Cluster:
+        return self
+
+    def __exit__(self, *args):
+        pass
+
     @property
     def cluster_log_conf_str(self) -> str:
         return json.dumps(self.cluster_log_conf)

--- a/pyjaws/pyjaws/api/templates/macros/cluster.j2
+++ b/pyjaws/pyjaws/api/templates/macros/cluster.j2
@@ -24,7 +24,7 @@
         "cluster_log_conf": {{ cluster_specs.cluster_log_conf_str }},
         {% endif %}
     }
-}
+},
 {% endfilter %}
 {% endfor %}
 {% endmacro %}

--- a/tests/fixtures/job.py
+++ b/tests/fixtures/job.py
@@ -118,3 +118,37 @@ def workflow_fixture_no_tags() -> Workflow:
     workflow = Workflow(name="test_workflow_iot", tasks=[aggregate_task])
 
     return workflow
+
+
+@pytest.fixture
+def workflow_multiple_cluster() -> Workflow:
+    cluster_1 = Cluster(
+        job_cluster_key="mycluster_1",
+        spark_version=Runtime.DBR_13_ML,
+        node_type_id="Standard_E4ds_v4",
+        num_workers=3,
+    )
+
+    task_1 = SparkPythonTask(
+        key="task_1",
+        cluster=cluster_1,
+        python_file="/Workspace/Repos/bob@mail.com/utils/task_1.py",
+        source=Source.WORKSPACE,
+    )
+
+    # cluster created with context manager
+    with Cluster(
+        job_cluster_key="mycluster_2",
+        spark_version=Runtime.DBR_13_ML,
+        node_type_id="Standard_E4ds_v4",
+        num_workers=3,
+    ) as cluster_2:
+        task_2 = SparkPythonTask(
+            key="task_2",
+            cluster=cluster_2,
+            python_file="/Workspace/Repos/bob@mail.com/utils/task_2.py",
+            source=Source.WORKSPACE,
+        )
+    workflow = Workflow(name="test_workflow_iot", tasks=[task_1, task_2])
+
+    return workflow

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,52 +1,62 @@
+import logging
+from unittest import mock
+
+import pytest
+from databricks_cli.jobs.api import JobsApi
 from pyjaws.api import jobs
+
 from tests.fixtures.job import (
     workflow_fixture,
-    workflow_fixture_no_tags
+    workflow_fixture_no_tags,
+    workflow_multiple_cluster,
 )
-from unittest import mock
-import logging
-from databricks_cli.jobs.api import JobsApi
 
 
-@mock.patch.object(JobsApi, "_list_jobs_by_name", mock.Mock(return_value = [{"job_id": "1234"}]))
-@mock.patch.object(JobsApi, "reset_job", mock.Mock(return_value = {}))
+@mock.patch.object(
+    JobsApi, "_list_jobs_by_name", mock.Mock(return_value=[{"job_id": "1234"}])
+)
+@mock.patch.object(JobsApi, "reset_job", mock.Mock(return_value={}))
 @mock.patch.dict(
     "os.environ",
     {
         "DATABRICKS_HOST": "test_host",
-        "DATABRICKS_TOKEN": "test_token"
+        "DATABRICKS_TOKEN": "test_token",
     },
 )
-def test_overwrite_job(workflow_fixture):
+@pytest.mark.parametrize(
+    "workflow_fixture_",
+    ["workflow_fixture", "workflow_multiple_cluster"],
+)
+def test_overwrite_job(workflow_fixture_, request):
     """Test for create_job."""
 
-    result = jobs.create(
-        workflow = workflow_fixture,
-        overwrite = True
-    )
+    workflow = request.getfixturevalue(workflow_fixture_)
+    result = jobs.create(workflow=workflow, overwrite=True)
 
     logging.info(f"Create result: {result}")
     assert isinstance(result, dict)
 
 
-@mock.patch.object(JobsApi, "_list_jobs_by_name", mock.Mock(return_value = []))
-@mock.patch.object(JobsApi, "create_job", mock.Mock(return_value = {"job_id": "123"}))
+@mock.patch.object(JobsApi, "_list_jobs_by_name", mock.Mock(return_value=[]))
+@mock.patch.object(JobsApi, "create_job", mock.Mock(return_value={"job_id": "123"}))
 @mock.patch.dict(
     "os.environ",
     {
         "DATABRICKS_HOST": "test_host",
-        "DATABRICKS_TOKEN": "test_token"
+        "DATABRICKS_TOKEN": "test_token",
     },
 )
-def test_create_job(workflow_fixture):
+@pytest.mark.parametrize(
+    "workflow_fixture_",
+    ["workflow_fixture", "workflow_multiple_cluster"],
+)
+def test_create_job(workflow_fixture_, request):
     """Test for create_job."""
 
-    logging.info(workflow_fixture.json())
+    workflow = request.getfixturevalue(workflow_fixture_)
+    logging.info(workflow.json())
 
-    result = jobs.create(
-        workflow = workflow_fixture,
-        overwrite = True
-    )
+    result = jobs.create(workflow=workflow, overwrite=True)
 
     logging.info(f"Create result: {result}")
     assert result
@@ -54,30 +64,24 @@ def test_create_job(workflow_fixture):
 
 
 def test_custom_tags(workflow_fixture):
-
     logging.info(workflow_fixture.tags)
     assert "test" in workflow_fixture.tags.keys()
 
 
-@mock.patch.object(JobsApi, "_list_jobs_by_name", mock.Mock(return_value = []))
-@mock.patch.object(JobsApi, "create_job", mock.Mock(return_value = {"job_id": "123"}))
+@mock.patch.object(JobsApi, "_list_jobs_by_name", mock.Mock(return_value=[]))
+@mock.patch.object(JobsApi, "create_job", mock.Mock(return_value={"job_id": "123"}))
 @mock.patch.dict(
     "os.environ",
     {
         "DATABRICKS_HOST": "test_host",
-        "DATABRICKS_TOKEN": "test_token"
+        "DATABRICKS_TOKEN": "test_token",
     },
 )
 def test_create_no_tags(workflow_fixture_no_tags):
-
     """Test for create_job."""
 
-    result = jobs.create(
-        workflow = workflow_fixture_no_tags,
-        overwrite = True
-    )
+    result = jobs.create(workflow=workflow_fixture_no_tags, overwrite=True)
 
     logging.info(f"Create result: {result}")
     assert result
     assert result["job_id"]
-   


### PR DESCRIPTION
Adds changes for #10 

- Add context manager syntax for clusters
- Add workflow with multiple cluster in test fixture
- Parameterize tests to use fixtures
- Fix for cluster template failing when workflow with multiple cluster is created
- Formatted with black

What types of changes does your code introduce to dbx? Put an x in the boxes that apply

    [x] Bugfix (non-breaking change which fixes an issue)
    [x] New feature (non-breaking change which adds functionality)
