### PR TITLE
add implicit cluster to tasks within cluster manager syntax

### DIFF
--- a/pyjaws/pyjaws/api/base.py
+++ b/pyjaws/pyjaws/api/base.py
@@ -32,8 +32,8 @@ class Cluster(BaseModel):
     instance_pool_id: Optional[str] = None
     runtime_engine: Optional[str] = None
     cluster_log_conf: Optional[dict] = None
-    __cluster: List[Cluster] = []
-    __lock: Lock = Lock()
+    __cluster: List[Cluster] = []  # mutable list to store current instance
+    __lock: Lock = Lock()  # to prevent race conditions
 
     def __init__(self, **kwargs):
         """
@@ -55,6 +55,7 @@ class Cluster(BaseModel):
         return self.job_cluster_key
 
     def __enter__(self) -> Cluster:
+        """Injects cluster instance into tasks created within context manger syntax."""
         if self.__cluster:
             raise Exception("Nested clusters are not supported!!")
         self.__lock.acquire()
@@ -67,6 +68,7 @@ class Cluster(BaseModel):
 
     @classmethod
     def _get_cluster(cls) -> Cluster:
+        """A helper method to return the cluster instance."""
         if cls.__cluster:
             return cls.__cluster[-1]
         else:

--- a/tests/fixtures/job.py
+++ b/tests/fixtures/job.py
@@ -149,13 +149,26 @@ def workflow_multiple_cluster() -> Workflow:
             python_file="/Workspace/Repos/bob@mail.com/utils/task_2.py",
             source=Source.WORKSPACE,
         )
-    workflow = Workflow(name="test_workflow_iot", tasks=[task_1, task_2])
+
+    # task created without explicit cluster reference within context manager
+    with Cluster(
+        job_cluster_key="mycluster_3",
+        spark_version=Runtime.DBR_13_ML,
+        node_type_id="Standard_E4ds_v4",
+        num_workers=3,
+    ):
+        task_3 = SparkPythonTask(
+            key="task_3",
+            python_file="/Workspace/Repos/bob@mail.com/utils/task_3.py",
+            source=Source.WORKSPACE,
+        )
+    workflow = Workflow(name="test_workflow_iot", tasks=[task_1, task_2, task_3])
 
     return workflow
 
+
 @pytest.fixture
 def cluster() -> Cluster:
-
     cluster = Cluster(
         job_cluster_key="mycluster_1",
         spark_version=Runtime.DBR_13_ML,


### PR DESCRIPTION
Proposed changes

Adds a feature to assign implicit cluster when tasks are created within the context manager syntax for cluster for #22.

This feature is added via a mutable class variable `__cluster`, which gets updated within the cluster context manager context and uses a helper class method to access this variable. 

Types of changes

What types of changes does your code introduce to dbx? Put an x in the boxes that apply

    [x] New feature (non-breaking change which adds functionality)
